### PR TITLE
Universal Clipboard

### DIFF
--- a/llitgi/ViewControllers/Lists/ListViewController.swift
+++ b/llitgi/ViewControllers/Lists/ListViewController.swift
@@ -153,7 +153,8 @@ class ListViewController: UITableViewController {
     
     @IBAction private func addButtonTapped(_ sender: UIButton) {
         self.navigationItem.rightBarButtonItem = self.loadingButton
-        guard let url = UIPasteboard.general.url else {
+        guard let pasteboardItem = UIPasteboard.general.string,
+            let url = URL(string: pasteboardItem) else {
             UINotificationFeedbackGenerator().notificationOccurred(.error)
             self.navigationItem.rightBarButtonItem = self.addButton
 


### PR DESCRIPTION
Fix #26 

This seems to be actually a bug in [UIPasteboard](https://developer.apple.com/documentation/uikit/uipasteboard). 

When a URL is saved into the clipboard from another device (universal clipboard), the `url` property of UIPasteboard returns `nil` even though the clipboard contains a valid URL.

As a workaround this PR fetches the content of UIPasteboard as `String` and try to build a `URL` with it.

<img width="1072" alt="universal clipboard" src="https://user-images.githubusercontent.com/2320840/43492337-c36f3d60-9528-11e8-9fe3-1a27038bd966.png">