### PR TITLE
iPad support

### DIFF
--- a/llitgi.xcodeproj/project.pbxproj
+++ b/llitgi.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B5C90C72115756A002CDB9B /* FlowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5C90C62115756A002CDB9B /* FlowManager.swift */; };
+		0B8227402107B7FF007CF8F3 /* SplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B82273F2107B7FF007CF8F3 /* SplitViewController.swift */; };
+		0B8227442107C2AD007CF8F3 /* SafariShowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8227432107C2AD007CF8F3 /* SafariShowing.swift */; };
 		4710EF461FF2C5B000D3DCA9 /* PocketAPIModification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4710EF451FF2C5B000D3DCA9 /* PocketAPIModification.swift */; };
 		4710EF521FF3FC6A00D3DCA9 /* ListSwipeActionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4710EF511FF3FC6A00D3DCA9 /* ListSwipeActionManager.swift */; };
 		4710EF561FF4338A00D3DCA9 /* CoreDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4710EF551FF4338A00D3DCA9 /* CoreDataFactory.swift */; };
@@ -91,6 +94,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0B5C90C62115756A002CDB9B /* FlowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowManager.swift; sourceTree = "<group>"; };
+		0B82273F2107B7FF007CF8F3 /* SplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewController.swift; sourceTree = "<group>"; };
+		0B8227432107C2AD007CF8F3 /* SafariShowing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariShowing.swift; sourceTree = "<group>"; };
 		4710EF451FF2C5B000D3DCA9 /* PocketAPIModification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketAPIModification.swift; sourceTree = "<group>"; };
 		4710EF511FF3FC6A00D3DCA9 /* ListSwipeActionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSwipeActionManager.swift; sourceTree = "<group>"; };
 		4710EF551FF4338A00D3DCA9 /* CoreDataFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataFactory.swift; sourceTree = "<group>"; };
@@ -226,8 +232,10 @@
 		47803EA320096727003D58E2 /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				0B8227432107C2AD007CF8F3 /* SafariShowing.swift */,
 				47803EA42009674D003D58E2 /* UserManager.swift */,
 				4710EF511FF3FC6A00D3DCA9 /* ListSwipeActionManager.swift */,
+				0B5C90C62115756A002CDB9B /* FlowManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -282,6 +290,7 @@
 			children = (
 				47EEA3861FF038EC0030BEF1 /* ViewControllerFactory.swift */,
 				478F43822037078C003ECCAD /* TabBarController.swift */,
+				0B82273F2107B7FF007CF8F3 /* SplitViewController.swift */,
 				47EEA37B1FF035A20030BEF1 /* Authorization */,
 				4752C0842030F20300988A68 /* FullSync */,
 				4770ACF81FF189CD006E755D /* Lists */,
@@ -507,14 +516,17 @@
 				47376DE41FF07F9500B8E70C /* Logger.swift in Sources */,
 				47EEA3901FF076AA0030BEF1 /* PocketAPIError.swift in Sources */,
 				4752C0872030F22300988A68 /* FullSyncViewController.swift in Sources */,
+				0B5C90C72115756A002CDB9B /* FlowManager.swift in Sources */,
 				4710EF611FF51D8500D3DCA9 /* Managed.swift in Sources */,
 				47EEA38D1FF074C70030BEF1 /* Typealias.swift in Sources */,
 				47EEA3871FF038EC0030BEF1 /* ViewControllerFactory.swift in Sources */,
 				4770ACFE1FF1B108006E755D /* ListDataSource.swift in Sources */,
 				4710EF521FF3FC6A00D3DCA9 /* ListSwipeActionManager.swift in Sources */,
+				0B8227442107C2AD007CF8F3 /* SafariShowing.swift in Sources */,
 				4710EF581FF44E5100D3DCA9 /* CoreDataNotifier.swift in Sources */,
 				47EEA3851FF038300030BEF1 /* PocketAPIManager.swift in Sources */,
 				471FE2E920B5EFED0059AEA7 /* UIViewController.swift in Sources */,
+				0B8227402107B7FF007CF8F3 /* SplitViewController.swift in Sources */,
 				4770ACFB1FF18AF7006E755D /* ListViewController.swift in Sources */,
 				47392348202667E3005526C5 /* LitgiUserDefaults.swift in Sources */,
 				47EEA3831FF037D40030BEF1 /* DataProvider.swift in Sources */,

--- a/llitgi.xcodeproj/project.pbxproj
+++ b/llitgi.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0B5C90C72115756A002CDB9B /* FlowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5C90C62115756A002CDB9B /* FlowManager.swift */; };
+		0B5C90C921157BE3002CDB9B /* OverlayDisplaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5C90C821157BE3002CDB9B /* OverlayDisplaying.swift */; };
 		0B8227402107B7FF007CF8F3 /* SplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B82273F2107B7FF007CF8F3 /* SplitViewController.swift */; };
 		0B8227442107C2AD007CF8F3 /* SafariShowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8227432107C2AD007CF8F3 /* SafariShowing.swift */; };
 		4710EF461FF2C5B000D3DCA9 /* PocketAPIModification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4710EF451FF2C5B000D3DCA9 /* PocketAPIModification.swift */; };
@@ -95,6 +96,7 @@
 
 /* Begin PBXFileReference section */
 		0B5C90C62115756A002CDB9B /* FlowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowManager.swift; sourceTree = "<group>"; };
+		0B5C90C821157BE3002CDB9B /* OverlayDisplaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayDisplaying.swift; sourceTree = "<group>"; };
 		0B82273F2107B7FF007CF8F3 /* SplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewController.swift; sourceTree = "<group>"; };
 		0B8227432107C2AD007CF8F3 /* SafariShowing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariShowing.swift; sourceTree = "<group>"; };
 		4710EF451FF2C5B000D3DCA9 /* PocketAPIModification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketAPIModification.swift; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 				47803EA42009674D003D58E2 /* UserManager.swift */,
 				4710EF511FF3FC6A00D3DCA9 /* ListSwipeActionManager.swift */,
 				0B5C90C62115756A002CDB9B /* FlowManager.swift */,
+				0B5C90C821157BE3002CDB9B /* OverlayDisplaying.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -545,6 +548,7 @@
 				478F43852038B24E003ECCAD /* UITableView.swift in Sources */,
 				4770AD001FF1B3B8006E755D /* ReusableCells.swift in Sources */,
 				47EEA38B1FF071FF0030BEF1 /* PocketAPIConfiguration.swift in Sources */,
+				0B5C90C921157BE3002CDB9B /* OverlayDisplaying.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/llitgi.xcodeproj/project.pbxproj
+++ b/llitgi.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		0B5C90C921157BE3002CDB9B /* OverlayDisplaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5C90C821157BE3002CDB9B /* OverlayDisplaying.swift */; };
 		0B8227402107B7FF007CF8F3 /* SplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B82273F2107B7FF007CF8F3 /* SplitViewController.swift */; };
 		0B8227442107C2AD007CF8F3 /* SafariShowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8227432107C2AD007CF8F3 /* SafariShowing.swift */; };
+		0BEA39C82115F2D7003238C7 /* EmptyDetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0BEA39C72115F2D7003238C7 /* EmptyDetailViewController.xib */; };
+		0BEA39CA2115F373003238C7 /* EmptyDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEA39C92115F373003238C7 /* EmptyDetailViewController.swift */; };
 		4710EF461FF2C5B000D3DCA9 /* PocketAPIModification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4710EF451FF2C5B000D3DCA9 /* PocketAPIModification.swift */; };
 		4710EF521FF3FC6A00D3DCA9 /* ListSwipeActionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4710EF511FF3FC6A00D3DCA9 /* ListSwipeActionManager.swift */; };
 		4710EF561FF4338A00D3DCA9 /* CoreDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4710EF551FF4338A00D3DCA9 /* CoreDataFactory.swift */; };
@@ -99,6 +101,8 @@
 		0B5C90C821157BE3002CDB9B /* OverlayDisplaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayDisplaying.swift; sourceTree = "<group>"; };
 		0B82273F2107B7FF007CF8F3 /* SplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewController.swift; sourceTree = "<group>"; };
 		0B8227432107C2AD007CF8F3 /* SafariShowing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariShowing.swift; sourceTree = "<group>"; };
+		0BEA39C72115F2D7003238C7 /* EmptyDetailViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmptyDetailViewController.xib; sourceTree = "<group>"; };
+		0BEA39C92115F373003238C7 /* EmptyDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyDetailViewController.swift; sourceTree = "<group>"; };
 		4710EF451FF2C5B000D3DCA9 /* PocketAPIModification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketAPIModification.swift; sourceTree = "<group>"; };
 		4710EF511FF3FC6A00D3DCA9 /* ListSwipeActionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSwipeActionManager.swift; sourceTree = "<group>"; };
 		4710EF551FF4338A00D3DCA9 /* CoreDataFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataFactory.swift; sourceTree = "<group>"; };
@@ -170,6 +174,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0BEA39C62115F2A9003238C7 /* EmptyDetail */ = {
+			isa = PBXGroup;
+			children = (
+				0BEA39C72115F2D7003238C7 /* EmptyDetailViewController.xib */,
+				0BEA39C92115F373003238C7 /* EmptyDetailViewController.swift */,
+			);
+			path = EmptyDetail;
+			sourceTree = "<group>";
+		};
 		4710EF541FF4333600D3DCA9 /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
@@ -298,6 +311,7 @@
 				4752C0842030F20300988A68 /* FullSync */,
 				4770ACF81FF189CD006E755D /* Lists */,
 				474B441D2001A517009897D2 /* Settings */,
+				0BEA39C62115F2A9003238C7 /* EmptyDetail */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -465,6 +479,7 @@
 				4752C0882030F22300988A68 /* FullSyncViewController.xib in Resources */,
 				478F43992038E52D003ECCAD /* Localizable.strings in Resources */,
 				47EEA37F1FF035C80030BEF1 /* AuthorizationViewController.xib in Resources */,
+				0BEA39C82115F2D7003238C7 /* EmptyDetailViewController.xib in Resources */,
 				4770AD041FF1B470006E755D /* ListCell.xib in Resources */,
 				47DB058220B067DB001485DF /* Assets.xcassets in Resources */,
 				479E18E520724653002E3BB1 /* PocketConsumerKey in Resources */,
@@ -546,6 +561,7 @@
 				47A493A7203F6E6B004051A6 /* Bundle.swift in Sources */,
 				474B44202001A52D009897D2 /* SettingsViewController.swift in Sources */,
 				478F43852038B24E003ECCAD /* UITableView.swift in Sources */,
+				0BEA39CA2115F373003238C7 /* EmptyDetailViewController.swift in Sources */,
 				4770AD001FF1B3B8006E755D /* ReusableCells.swift in Sources */,
 				47EEA38B1FF071FF0030BEF1 /* PocketAPIConfiguration.swift in Sources */,
 				0B5C90C921157BE3002CDB9B /* OverlayDisplaying.swift in Sources */,

--- a/llitgi/AppDelegate.swift
+++ b/llitgi/AppDelegate.swift
@@ -14,17 +14,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private let window = UIWindow(frame: UIScreen.main.bounds)
     private let dataProvider = DataProvider(pocketAPI: PocketAPIManager(), modelFactory: CoreDataFactoryImplementation())
     private let userManager: UserManager = UserPreferencesManager()
+    private var flowManager: FlowManager?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         
         UIApplication.shared.setMinimumBackgroundFetchInterval(1800)
         
-        let flowManager = FlowManager(window: window, dataProvider: dataProvider, userManager: userManager)
+        flowManager = FlowManager(window: window, dataProvider: dataProvider, userManager: userManager)
         
         if self.userManager.isLoggedIn {
-            flowManager.setupMainFlow()
+            flowManager?.setupMainFlow()
         } else {
-            flowManager.setupAuthFlow()
+            flowManager?.setupAuthFlow()
         }
         
         // Establishing the window and rootViewController

--- a/llitgi/AppDelegate.swift
+++ b/llitgi/AppDelegate.swift
@@ -19,19 +19,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         UIApplication.shared.setMinimumBackgroundFetchInterval(1800)
         
-        let viewControllerFactory = ViewControllerFactory(dataProvider: self.dataProvider, userManager: self.userManager)
+        let flowManager = FlowManager(window: window, dataProvider: dataProvider, userManager: userManager)
         
-        let rootViewController = TabBarController(factory: viewControllerFactory)
         if self.userManager.isLoggedIn {
-            rootViewController.setupMainFlow()
+            flowManager.setupMainFlow()
         } else {
-            rootViewController.setupAuthFlow()
+            flowManager.setupAuthFlow()
         }
         
         // Establishing the window and rootViewController
         self.window.makeKeyAndVisible()
         self.window.tintColor = .black
-        self.window.rootViewController = rootViewController
         
         return true
     }

--- a/llitgi/Extensions & Helpers/L10n.swift
+++ b/llitgi/Extensions & Helpers/L10n.swift
@@ -79,6 +79,8 @@ enum L10n {
         static let safariOpenerDescription = NSLocalizedString("Settings.safariOpenerExplanation", comment: "")
         static let safariReaderTitle = NSLocalizedString("Settings.safariReaderTitle", comment: "")
         static let safariReaderDescription = NSLocalizedString("Settings.safariReaderExplanation", comment: "")
+        static let overlayModeTitle = NSLocalizedString("Settings.overlayModeTitle", comment: "")
+        static let overlayModeDescription = NSLocalizedString("Settings.overlayModeDescription", comment: "")
         static let github = NSLocalizedString("Settings.github", comment: "")
         static let twitter = NSLocalizedString("Settings.twitter", comment: "")
         static let email = NSLocalizedString("Settings.email", comment: "")

--- a/llitgi/Extensions & Helpers/L10n.swift
+++ b/llitgi/Extensions & Helpers/L10n.swift
@@ -87,6 +87,10 @@ enum L10n {
         static let buildVersion = NSLocalizedString("Settings.buildVersion", comment: "")
     }
     
+    enum EmptyDetail {
+        static let descriptionTitle = NSLocalizedString("EmptyDetail.description", comment: "")
+    }
+    
     enum ShareExtension {
         static let saving = NSLocalizedString("ShareExtension.saving", comment: "")
     }

--- a/llitgi/Extensions & Helpers/LitgiUserDefaults.swift
+++ b/llitgi/Extensions & Helpers/LitgiUserDefaults.swift
@@ -14,6 +14,7 @@ let kSafariOpener = "safariOpener"
 let kReaderMode = "readerMode"
 let kLastSync = "lastSync"
 let kGroupUserDefaults = "group.com.xmollv.llitgi"
+let kEnabledOverlayMode = "enabledOverlayMode"
 
 final class LlitgiUserDefaults {
     private init() {}

--- a/llitgi/Managers/FlowManager.swift
+++ b/llitgi/Managers/FlowManager.swift
@@ -1,0 +1,42 @@
+//
+//  FlowManager.swift
+//  llitgi
+//
+//  Created by Adrian Tineo on 04.08.18.
+//  Copyright © 2018 xmollv. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class FlowManager {
+    private let window: UIWindow
+    private let dataProvider: DataProvider
+    private let userManager: UserManager
+    
+    init(window: UIWindow, dataProvider: DataProvider, userManager: UserManager) {
+        self.window = window
+        self.dataProvider = dataProvider
+        self.userManager = userManager
+    }
+    
+    func setupAuthFlow() {
+        // AuthFlow uses TabBarController
+        let viewControllerFactory = ViewControllerFactory(dataProvider: self.dataProvider, userManager: self.userManager, flowManager: self)
+        let rootViewController = TabBarController(factory: viewControllerFactory)
+        
+        rootViewController.setupAuthFlow()
+        window.rootViewController = rootViewController
+    }
+    
+    func setupMainFlow() {
+        // MainFlow uses SplitViewController
+        let viewControllerFactory = ViewControllerFactory(dataProvider: self.dataProvider, userManager: self.userManager, flowManager: self)
+        let rootViewController = SplitViewController(factory: viewControllerFactory)
+        // Can't be injected at initializer due to circular dependency
+        viewControllerFactory.safariShowing = rootViewController
+        
+        rootViewController.setupMainFlow()
+        window.rootViewController = rootViewController
+    }
+}

--- a/llitgi/Managers/FlowManager.swift
+++ b/llitgi/Managers/FlowManager.swift
@@ -37,7 +37,7 @@ class FlowManager {
         viewControllerFactory.safariShowing = rootViewController
         viewControllerFactory.overlayDisplaying = rootViewController
         
-        rootViewController.setupMainFlow()
+        rootViewController.setupMainFlow(shouldEnableOverlayMode: self.userManager.userHasEnabledOverlayMode)
         window.rootViewController = rootViewController
     }
 }

--- a/llitgi/Managers/FlowManager.swift
+++ b/llitgi/Managers/FlowManager.swift
@@ -35,6 +35,7 @@ class FlowManager {
         let rootViewController = SplitViewController(factory: viewControllerFactory)
         // Can't be injected at initializer due to circular dependency
         viewControllerFactory.safariShowing = rootViewController
+        viewControllerFactory.overlayDisplaying = rootViewController
         
         rootViewController.setupMainFlow()
         window.rootViewController = rootViewController

--- a/llitgi/Managers/OverlayDisplaying.swift
+++ b/llitgi/Managers/OverlayDisplaying.swift
@@ -1,0 +1,14 @@
+//
+//  OverlayDisplaying.swift
+//  llitgi
+//
+//  Created by Adrian Tineo on 04.08.18.
+//  Copyright © 2018 xmollv. All rights reserved.
+//
+
+import Foundation
+
+protocol OverlayDisplaying: class {
+    func overlayDisplayMode(shouldBeSet: Bool)
+    func isOverlayDisplayModeSet() -> Bool
+}

--- a/llitgi/Managers/OverlayDisplaying.swift
+++ b/llitgi/Managers/OverlayDisplaying.swift
@@ -9,6 +9,5 @@
 import Foundation
 
 protocol OverlayDisplaying: class {
-    func overlayDisplayMode(shouldBeSet: Bool)
-    func isOverlayDisplayModeSet() -> Bool
+    func overlayDisplayMode(isEnabled: Bool)
 }

--- a/llitgi/Managers/SafariShowing.swift
+++ b/llitgi/Managers/SafariShowing.swift
@@ -1,0 +1,14 @@
+//
+//  SafariShowing.swift
+//  llitgi
+//
+//  Created by Adrian Tineo on 24.07.18.
+//  Copyright © 2018 xmollv. All rights reserved.
+//
+
+import Foundation
+import SafariServices
+
+protocol SafariShowing: class {
+    func show(safariViewController: SFSafariViewController)
+}

--- a/llitgi/Managers/UserManager.swift
+++ b/llitgi/Managers/UserManager.swift
@@ -25,6 +25,7 @@ protocol UserManager: class {
     var openReaderMode: Bool { get set }
     var badgeDelegate: BadgeDelegate? { get set }
     var userHasEnabledNotifications: Bool { get }
+    var userHasEnabledOverlayMode: Bool { get set }
     
     func enableBadge(shouldEnable: Bool, then: @escaping (Bool)->())
     func displayBadge(with: Int)
@@ -67,6 +68,11 @@ class UserPreferencesManager: UserManager {
             return savedValue
         }
         set { LlitgiUserDefaults.shared.set(newValue, forKey: kReaderMode) }
+    }
+    
+    var userHasEnabledOverlayMode: Bool {
+        get { return LlitgiUserDefaults.shared.bool(forKey: kEnabledOverlayMode) }
+        set { LlitgiUserDefaults.shared.set(newValue, forKey: kEnabledOverlayMode)}
     }
     
     func enableBadge(shouldEnable: Bool, then: @escaping (Bool) -> ()) {

--- a/llitgi/Resources/en.lproj/Localizable.strings
+++ b/llitgi/Resources/en.lproj/Localizable.strings
@@ -55,4 +55,6 @@
 "Settings.email" = "Email";
 "Settings.buildVersion" = "Version: %1$@";
 
+"EmptyDetail.description" = "Choose an item from the list to start reading.";
+
 "ShareExtension.saving" = "Saving to Llitgi...";

--- a/llitgi/Resources/en.lproj/Localizable.strings
+++ b/llitgi/Resources/en.lproj/Localizable.strings
@@ -55,6 +55,6 @@
 "Settings.email" = "Email";
 "Settings.buildVersion" = "Version: %1$@";
 
-"EmptyDetail.description" = "Choose an item from the list to start reading.";
+"EmptyDetail.description" = "Choose an item from the list to start reading.\n You may need to swipe from the left edge if using overlay mode.";
 
 "ShareExtension.saving" = "Saving to Llitgi...";

--- a/llitgi/Resources/en.lproj/Localizable.strings
+++ b/llitgi/Resources/en.lproj/Localizable.strings
@@ -48,6 +48,8 @@
 "Settings.safariOpenerExplanation" = "We'll launch Safari with the item that you've selected instead of using the in-app browser.";
 "Settings.safariReaderTitle" = "Reader View";
 "Settings.safariReaderExplanation" = "We'll open all your items in Reader View. Some websites may not support this feature.";
+"Settings.overlayModeTitle" = "Overlay Mode";
+"Settings.overlayModeDescription"= "Allows to read in full screen on iPad. Pull from the left side to reveal list of items.";
 "Settings.github" = "GitHub";
 "Settings.twitter" = "Twitter";
 "Settings.email" = "Email";

--- a/llitgi/ViewControllers/Authorization/AuthorizationViewController.swift
+++ b/llitgi/ViewControllers/Authorization/AuthorizationViewController.swift
@@ -24,11 +24,13 @@ class AuthorizationViewController: UIViewController {
     //MARK: Provate properties
     private let dataProvider: DataProvider
     private let factory: ViewControllerFactory
+    private let flowManager: FlowManager
     
     //MARK:- Lifecycle
-    init(dataProvider: DataProvider, factory: ViewControllerFactory) {
+    init(dataProvider: DataProvider, factory: ViewControllerFactory, flowManager: FlowManager) {
         self.dataProvider = dataProvider
         self.factory = factory
+        self.flowManager = flowManager
         super.init(nibName: String(describing: AuthorizationViewController.self), bundle: nil)
     }
     
@@ -121,7 +123,7 @@ class AuthorizationViewController: UIViewController {
         fullSync.modalPresentationStyle = .overFullScreen
         fullSync.modalTransitionStyle = .crossDissolve
         tabBarController.present(fullSync, animated: true, completion: nil)
-        tabBarController.setupMainFlow()
+        flowManager.setupMainFlow()
     }
 
 }

--- a/llitgi/ViewControllers/Authorization/AuthorizationViewController.xib
+++ b/llitgi/ViewControllers/Authorization/AuthorizationViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,24 +24,24 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="i5M-Pr-FkT">
             <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Welcome to Llitgi" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RH9-CI-Pq8">
-                    <rect key="frame" x="20" y="84" width="335" height="119.66666666666669"/>
+                    <rect key="frame" x="36" y="84" width="303" height="119.66666666666669"/>
                     <fontDescription key="fontDescription" type="system" weight="black" pointSize="50"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PMT-55-GZN">
-                    <rect key="frame" x="20" y="203.66666666666666" width="335" height="483.33333333333337"/>
+                <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PMT-55-GZN">
+                    <rect key="frame" x="36" y="203.66666666666666" width="303" height="483.33333333333337"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="EhB-Kx-Cw4">
-                            <rect key="frame" x="0.0" y="122.33333333333334" width="335" height="240.00000000000003"/>
+                            <rect key="frame" x="0.0" y="122.00000000000003" width="303" height="239.99999999999997"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ExH-Xh-jTv">
-                                    <rect key="frame" x="0.0" y="0.0" width="335" height="60"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="303" height="60"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="open-book" translatesAutoresizingMaskIntoConstraints="NO" id="mIj-4c-GFg">
                                             <rect key="frame" x="0.0" y="0.0" width="60" height="60"/>
@@ -50,16 +51,16 @@
                                             </constraints>
                                         </imageView>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="sH3-cT-CdU">
-                                            <rect key="frame" x="70" y="9.3333333333333144" width="265" height="41"/>
+                                            <rect key="frame" x="70" y="9.3333333333333144" width="233" height="41"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iZJ-CX-DgA">
-                                                    <rect key="frame" x="0.0" y="0.0" width="265" height="18"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="233" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8XT-P9-AyU">
-                                                    <rect key="frame" x="0.0" y="23" width="265" height="18"/>
+                                                    <rect key="frame" x="0.0" y="23" width="233" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -69,7 +70,7 @@
                                     </subviews>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ki2-e1-uGF">
-                                    <rect key="frame" x="0.0" y="90" width="335" height="60"/>
+                                    <rect key="frame" x="0.0" y="90" width="303" height="60"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="sync" translatesAutoresizingMaskIntoConstraints="NO" id="4WU-Hz-wty">
                                             <rect key="frame" x="0.0" y="0.0" width="60" height="60"/>
@@ -79,16 +80,16 @@
                                             </constraints>
                                         </imageView>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="PXY-0c-zfq">
-                                            <rect key="frame" x="70" y="9.3333333333333144" width="265" height="41"/>
+                                            <rect key="frame" x="70" y="9.3333333333333144" width="233" height="41"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gc2-2y-dwf">
-                                                    <rect key="frame" x="0.0" y="0.0" width="265" height="18"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="233" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CDd-ud-iep">
-                                                    <rect key="frame" x="0.0" y="23" width="265" height="18"/>
+                                                    <rect key="frame" x="0.0" y="23" width="233" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -99,7 +100,7 @@
                                     <viewLayoutGuide key="safeArea" id="xPj-bn-gYQ"/>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="KxN-7O-j6M">
-                                    <rect key="frame" x="0.0" y="180" width="335" height="60"/>
+                                    <rect key="frame" x="0.0" y="180" width="303" height="60"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="github-logo" translatesAutoresizingMaskIntoConstraints="NO" id="yU8-vo-syG">
                                             <rect key="frame" x="0.0" y="0.0" width="60" height="60"/>
@@ -109,16 +110,16 @@
                                             </constraints>
                                         </imageView>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="pSO-QD-GaB">
-                                            <rect key="frame" x="70" y="9.3333333333333712" width="265" height="41"/>
+                                            <rect key="frame" x="70" y="9.3333333333333144" width="233" height="41"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JdQ-ru-dch">
-                                                    <rect key="frame" x="0.0" y="0.0" width="265" height="18"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="233" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eaa-Lc-lvR">
-                                                    <rect key="frame" x="0.0" y="23" width="265" height="18"/>
+                                                    <rect key="frame" x="0.0" y="23" width="233" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -165,15 +166,15 @@
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="RH9-CI-Pq8" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" priority="250" constant="40" id="0yb-Zv-vrS"/>
+                <constraint firstItem="PMT-55-GZN" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leadingMargin" constant="20" id="77Z-PA-5zO"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="G3b-Yf-I8e" secondAttribute="bottom" constant="20" id="7bT-e2-UYc"/>
-                <constraint firstItem="PMT-55-GZN" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="BSQ-oy-cE3"/>
+                <constraint firstAttribute="trailingMargin" secondItem="PMT-55-GZN" secondAttribute="trailing" constant="20" id="JSS-yO-zSn"/>
                 <constraint firstItem="PMT-55-GZN" firstAttribute="top" secondItem="RH9-CI-Pq8" secondAttribute="bottom" id="XAn-Cl-mCH"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="PMT-55-GZN" secondAttribute="trailing" constant="20" id="fOE-0e-qXO"/>
+                <constraint firstItem="RH9-CI-Pq8" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leadingMargin" constant="20" id="hOM-sK-yMA"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="G3b-Yf-I8e" secondAttribute="bottom" priority="250" constant="40" id="hi4-RH-9nX"/>
                 <constraint firstItem="RH9-CI-Pq8" firstAttribute="top" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="top" id="idE-vB-LQR"/>
+                <constraint firstAttribute="trailingMargin" secondItem="RH9-CI-Pq8" secondAttribute="trailing" constant="20" id="l6v-ih-IEX"/>
                 <constraint firstItem="G3b-Yf-I8e" firstAttribute="top" secondItem="PMT-55-GZN" secondAttribute="bottom" id="rXN-Nc-S2b"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="RH9-CI-Pq8" secondAttribute="trailing" constant="20" id="tZ1-Oq-rlJ"/>
-                <constraint firstItem="RH9-CI-Pq8" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="uSF-lB-dB5"/>
                 <constraint firstItem="G3b-Yf-I8e" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="xBX-RX-26f"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>

--- a/llitgi/ViewControllers/EmptyDetail/EmptyDetailViewController.swift
+++ b/llitgi/ViewControllers/EmptyDetail/EmptyDetailViewController.swift
@@ -16,5 +16,4 @@ class EmptyDetailViewController: UIViewController {
         super.viewDidLoad()
         descriptionLabel.text = L10n.EmptyDetail.descriptionTitle
     }
-    
 }

--- a/llitgi/ViewControllers/EmptyDetail/EmptyDetailViewController.swift
+++ b/llitgi/ViewControllers/EmptyDetail/EmptyDetailViewController.swift
@@ -1,0 +1,20 @@
+//
+//  EmptyDetailViewController.swift
+//  llitgi
+//
+//  Created by Adrian Tineo on 04.08.18.
+//  Copyright © 2018 xmollv. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class EmptyDetailViewController: UIViewController {
+    @IBOutlet weak var descriptionLabel: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        descriptionLabel.text = L10n.EmptyDetail.descriptionTitle
+    }
+    
+}

--- a/llitgi/ViewControllers/EmptyDetail/EmptyDetailViewController.xib
+++ b/llitgi/ViewControllers/EmptyDetail/EmptyDetailViewController.xib
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="EmptyDetailViewController" customModule="llitgi" customModuleProvider="target">
+            <connections>
+                <outlet property="descriptionLabel" destination="7Kq-7M-HJK" id="QQc-gq-abe"/>
+                <outlet property="view" destination="iN0-l3-epB" id="fai-x8-QaI"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="open-book" translatesAutoresizingMaskIntoConstraints="NO" id="oxV-nQ-UFQ">
+                    <rect key="frame" x="157.5" y="313.5" width="60" height="60"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="60" id="SoF-A7-YYb"/>
+                        <constraint firstAttribute="width" constant="60" id="uRX-LJ-5De"/>
+                    </constraints>
+                </imageView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Kq-7M-HJK">
+                    <rect key="frame" x="146.5" y="385.5" width="82.5" height="18"/>
+                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="7Kq-7M-HJK" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="10" id="1mq-EK-W9R"/>
+                <constraint firstItem="oxV-nQ-UFQ" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="9aA-wW-Q7J"/>
+                <constraint firstItem="oxV-nQ-UFQ" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="EgA-lp-suU"/>
+                <constraint firstItem="7Kq-7M-HJK" firstAttribute="top" secondItem="oxV-nQ-UFQ" secondAttribute="bottom" constant="12" id="TbC-wF-Z66"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7Kq-7M-HJK" secondAttribute="trailing" constant="10" id="thO-LD-71a"/>
+                <constraint firstItem="7Kq-7M-HJK" firstAttribute="centerX" secondItem="oxV-nQ-UFQ" secondAttribute="centerX" id="tjx-AF-vSl"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="open-book" width="60" height="60"/>
+    </resources>
+</document>

--- a/llitgi/ViewControllers/EmptyDetail/EmptyDetailViewController.xib
+++ b/llitgi/ViewControllers/EmptyDetail/EmptyDetailViewController.xib
@@ -27,7 +27,7 @@
                         <constraint firstAttribute="width" constant="60" id="uRX-LJ-5De"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Kq-7M-HJK">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="Description" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Kq-7M-HJK">
                     <rect key="frame" x="146.5" y="385.5" width="82.5" height="18"/>
                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                     <nil key="textColor"/>

--- a/llitgi/ViewControllers/Lists/ListViewController.swift
+++ b/llitgi/ViewControllers/Lists/ListViewController.swift
@@ -197,7 +197,7 @@ class ListViewController: UITableViewController {
         }
         let navController = UINavigationController(rootViewController: settingsViewController)
         navController.navigationBar.barTintColor = .white
-        navController.modalPresentationStyle = .pageSheet
+        navController.modalPresentationStyle = .formSheet
         self.present(navController, animated: true, completion: nil)
     }
 

--- a/llitgi/ViewControllers/Lists/ListViewController.swift
+++ b/llitgi/ViewControllers/Lists/ListViewController.swift
@@ -44,7 +44,7 @@ class ListViewController: UITableViewController {
             self.dataSource?.typeOfList = self.typeOfListForSearch
         }
     }
-    private let safariShowing: SafariShowing
+    private weak var safariShowing: SafariShowing?
     
     private lazy var customRefreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
@@ -191,7 +191,6 @@ class ListViewController: UITableViewController {
         //TODO: This is an extremely ugly hack, but I'm too tired rn
         settingsViewController.logoutBlock = { [weak self] in
             guard let strongSelf = self else { return }
-            guard let tabBar = strongSelf.tabBarController as? TabBarController  else { return }
             strongSelf.userManager.displayBadge(with: 0)
             strongSelf.dataProvider.clearLocalStorage()
             strongSelf.flowManager.setupAuthFlow()
@@ -218,7 +217,7 @@ extension ListViewController {
         switch self.userManager.openLinksWith {
         case .safariViewController:
             guard let sfs = self.safariViewController(at: indexPath) else { return }
-            safariShowing.show(safariViewController: sfs)
+            safariShowing?.show(safariViewController: sfs)
         case .safari:
             guard let url = self.dataSource?.item(at: indexPath)?.url else { return }
             UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/llitgi/ViewControllers/Lists/ListViewController.swift
+++ b/llitgi/ViewControllers/Lists/ListViewController.swift
@@ -31,6 +31,7 @@ class ListViewController: UITableViewController {
     private let factory: ViewControllerFactory
     private let dataProvider: DataProvider
     private let userManager: UserManager
+    private let flowManager: FlowManager
     private let typeOfList: TypeOfList
     private let swipeActionManager: ListSwipeActionManager
     private let searchController = UISearchController(searchResultsController: nil)
@@ -43,6 +44,7 @@ class ListViewController: UITableViewController {
             self.dataSource?.typeOfList = self.typeOfListForSearch
         }
     }
+    private let safariShowing: SafariShowing
     
     private lazy var customRefreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
@@ -51,13 +53,15 @@ class ListViewController: UITableViewController {
     }()
     
     //MARK:- Lifecycle
-    required init(dataProvider: DataProvider, factory: ViewControllerFactory, userManager: UserManager, type: TypeOfList) {
+    required init(dataProvider: DataProvider, factory: ViewControllerFactory, userManager: UserManager, type: TypeOfList, flowManager: FlowManager, safariShowing: SafariShowing) {
         self.factory = factory
         self.dataProvider = dataProvider
+        self.flowManager = flowManager
         self.userManager = userManager
         self.typeOfList = type
         self.typeOfListForSearch = type
         self.swipeActionManager = ListSwipeActionManager(dataProvider: dataProvider)
+        self.safariShowing = safariShowing
         super.init(nibName: String(describing: ListViewController.self), bundle: nil)
     }
     
@@ -190,7 +194,7 @@ class ListViewController: UITableViewController {
             guard let tabBar = strongSelf.tabBarController as? TabBarController  else { return }
             strongSelf.userManager.displayBadge(with: 0)
             strongSelf.dataProvider.clearLocalStorage()
-            tabBar.setupAuthFlow()
+            strongSelf.flowManager.setupAuthFlow()
         }
         let navController = UINavigationController(rootViewController: settingsViewController)
         navController.navigationBar.barTintColor = .white
@@ -214,7 +218,7 @@ extension ListViewController {
         switch self.userManager.openLinksWith {
         case .safariViewController:
             guard let sfs = self.safariViewController(at: indexPath) else { return }
-            self.present(sfs, animated: true, completion: nil)
+            safariShowing.show(safariViewController: sfs)
         case .safari:
             guard let url = self.dataSource?.item(at: indexPath)?.url else { return }
             UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/llitgi/ViewControllers/Lists/ListViewController.swift
+++ b/llitgi/ViewControllers/Lists/ListViewController.swift
@@ -197,6 +197,7 @@ class ListViewController: UITableViewController {
         }
         let navController = UINavigationController(rootViewController: settingsViewController)
         navController.navigationBar.barTintColor = .white
+        navController.modalPresentationStyle = .pageSheet
         self.present(navController, animated: true, completion: nil)
     }
 

--- a/llitgi/ViewControllers/Settings/SettingsViewController.swift
+++ b/llitgi/ViewControllers/Settings/SettingsViewController.swift
@@ -11,20 +11,30 @@ import UIKit
 class SettingsViewController: UIViewController {
 
     //MARK:- IBOutlets
+    
+    // Badge count
     @IBOutlet private var badgeCountLabel: UILabel!
     @IBOutlet private var badgeCountExplanationLabel: UILabel!
     @IBOutlet private var badgeCountSwitch: UISwitch!
     
+    // Safari opener
     @IBOutlet private var safariOpenerLabel: UILabel!
     @IBOutlet private var safariOpenerExplanationLabel: UILabel!
     @IBOutlet private var safariOpenerSwitch: UISwitch!
     
+    // Safari reader
     @IBOutlet private var safariReaderModeLabel: UILabel!
     @IBOutlet private var safariReaderModeExplanationLabel: UILabel!
     @IBOutlet private var safariReaderModeSwitch: UISwitch!
     
-    @IBOutlet private var logoutButton: UIButton!
+    // Overlay mode
+    @IBOutlet weak var overlayModeStackView: UIStackView!
+    @IBOutlet weak var overlayModeLabel: UILabel!
+    @IBOutlet weak var overlayModeExplanationLabel: UILabel!
+    @IBOutlet weak var overlayModeSwitch: UISwitch!
     
+    // Other buttons
+    @IBOutlet private var logoutButton: UIButton!
     @IBOutlet private var githubButton: UIButton!
     @IBOutlet private var twitterButton: UIButton!
     @IBOutlet private var emailButton: UIButton!
@@ -57,13 +67,22 @@ class SettingsViewController: UIViewController {
         self.badgeCount(isEnabled: self.userManager.userHasEnabledNotifications)
         self.safariOpenerValue(opener: self.userManager.openLinksWith)
         self.establishReaderMode(readerEnabled: self.userManager.openReaderMode)
+        
+        if UIDevice.current.userInterfaceIdiom != .pad {
+            overlayModeStackView.isHidden = true
+        } else {
+            self.overlayMode(isEnabled: self.userManager.userHasEnabledOverlayMode)
+        }
     }
     
     //MARK:- IBActions
     @IBAction private func done(_ sender: UIBarButtonItem) {
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true) {
+            self.overlayDisplaying?.overlayDisplayMode(isEnabled: self.userManager.userHasEnabledOverlayMode)
+        }
     }
     
+    // Badge count
     private func badgeCount(isEnabled: Bool) {
         switch isEnabled {
         case true:
@@ -81,6 +100,7 @@ class SettingsViewController: UIViewController {
         }
     }
     
+    // Safari opener
     private func safariOpenerValue(opener: SafariOpener) {
         switch opener {
         case .safari:
@@ -99,6 +119,7 @@ class SettingsViewController: UIViewController {
         }
     }
     
+    // Reader mode
     private func establishReaderMode(readerEnabled: Bool) {
         self.safariReaderModeSwitch.setOn(readerEnabled, animated: false)
     }
@@ -107,6 +128,16 @@ class SettingsViewController: UIViewController {
         self.userManager.openReaderMode = sender.isOn
     }
     
+    // Overlay mode
+    private func overlayMode(isEnabled: Bool) {
+        self.overlayModeSwitch.setOn(isEnabled, animated: false)
+    }
+
+    @IBAction func overlayModeChanged(_ sender: UISwitch) {
+        self.userManager.userHasEnabledOverlayMode = sender.isOn
+    }
+    
+    // Other buttons
     @IBAction private func logoutButtonTapped(_ sender: UIButton) {
         self.dismiss(animated: true) {
             self.logoutBlock?()
@@ -137,6 +168,8 @@ class SettingsViewController: UIViewController {
         self.safariOpenerExplanationLabel.text = L10n.Settings.safariOpenerDescription
         self.safariReaderModeLabel.text = L10n.Settings.safariReaderTitle
         self.safariReaderModeExplanationLabel.text = L10n.Settings.safariReaderDescription
+        self.overlayModeLabel.text = L10n.Settings.overlayModeTitle
+        self.overlayModeExplanationLabel.text = L10n.Settings.overlayModeDescription
         self.logoutButton.setTitle(L10n.General.logout, for: .normal)
         self.githubButton.setTitle(L10n.Settings.github, for: .normal)
         self.twitterButton.setTitle(L10n.Settings.twitter, for: .normal)

--- a/llitgi/ViewControllers/Settings/SettingsViewController.swift
+++ b/llitgi/ViewControllers/Settings/SettingsViewController.swift
@@ -105,8 +105,9 @@ class SettingsViewController: UIViewController {
     }
     
     @IBAction private func logoutButtonTapped(_ sender: UIButton) {
-        self.logoutBlock?()
-        self.dismiss(animated: true, completion: nil)
+        self.dismiss(animated: true) {
+            self.logoutBlock?()
+        }
     }
     
     @IBAction func githubButtonTapped(_ sender: UIButton) {

--- a/llitgi/ViewControllers/Settings/SettingsViewController.swift
+++ b/llitgi/ViewControllers/Settings/SettingsViewController.swift
@@ -33,12 +33,15 @@ class SettingsViewController: UIViewController {
     //MARK: Private properties
     private let userManager: UserManager
     
+    private weak var overlayDisplaying: OverlayDisplaying?
+    
     //MARK: Public properties
     var logoutBlock: (() -> ())? = nil
     
     //MARK:- Lifecycle
-    init(userManager: UserManager) {
+    init(userManager: UserManager, overlayDisplaying: OverlayDisplaying) {
         self.userManager = userManager
+        self.overlayDisplaying = overlayDisplaying
         super.init(nibName: String(describing: SettingsViewController.self), bundle: nil)
     }
     

--- a/llitgi/ViewControllers/Settings/SettingsViewController.xib
+++ b/llitgi/ViewControllers/Settings/SettingsViewController.xib
@@ -5,6 +5,7 @@
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -40,7 +41,7 @@
                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6UK-5m-Gr8">
                     <rect key="frame" x="0.0" y="44" width="375" height="768"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hkm-EY-XLf">
+                        <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hkm-EY-XLf">
                             <rect key="frame" x="0.0" y="0.0" width="375.33333333333331" height="548"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="uNS-na-vvN">
@@ -272,12 +273,12 @@
                                 <constraint firstItem="spg-UY-3vD" firstAttribute="top" secondItem="geg-cl-9IZ" secondAttribute="bottom" constant="20" id="Et7-2y-ug6"/>
                                 <constraint firstItem="spg-UY-3vD" firstAttribute="trailing" secondItem="uNS-na-vvN" secondAttribute="trailing" constant="-20" id="LeT-Yr-xQ8"/>
                                 <constraint firstAttribute="bottom" secondItem="spg-UY-3vD" secondAttribute="bottom" constant="20" id="R7G-bM-N95"/>
-                                <constraint firstItem="uNS-na-vvN" firstAttribute="leading" secondItem="hkm-EY-XLf" secondAttribute="leading" constant="18" id="S9v-QX-sAz"/>
+                                <constraint firstItem="uNS-na-vvN" firstAttribute="leading" secondItem="hkm-EY-XLf" secondAttribute="leadingMargin" constant="10" id="S9v-QX-sAz"/>
                                 <constraint firstItem="uNS-na-vvN" firstAttribute="top" secondItem="hkm-EY-XLf" secondAttribute="top" constant="18" id="arS-oF-PZT"/>
                                 <constraint firstItem="geg-cl-9IZ" firstAttribute="top" secondItem="uNS-na-vvN" secondAttribute="bottom" constant="40" id="cCy-yi-4eH"/>
                                 <constraint firstItem="spg-UY-3vD" firstAttribute="leading" secondItem="uNS-na-vvN" secondAttribute="leading" constant="20" id="eaa-Ux-QxS"/>
                                 <constraint firstItem="geg-cl-9IZ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="uNS-na-vvN" secondAttribute="leading" priority="999" constant="20" id="kta-dj-UZJ"/>
-                                <constraint firstAttribute="trailing" secondItem="uNS-na-vvN" secondAttribute="trailing" constant="18" id="rQv-aw-bDi"/>
+                                <constraint firstAttribute="trailingMargin" secondItem="uNS-na-vvN" secondAttribute="trailing" constant="10" id="rQv-aw-bDi"/>
                             </constraints>
                         </view>
                     </subviews>

--- a/llitgi/ViewControllers/Settings/SettingsViewController.xib
+++ b/llitgi/ViewControllers/Settings/SettingsViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -18,6 +18,10 @@
                 <outlet property="emailButton" destination="dCE-EV-vXu" id="Xbe-6T-qeS"/>
                 <outlet property="githubButton" destination="Wfw-hB-TsU" id="f9c-NH-Ujc"/>
                 <outlet property="logoutButton" destination="geg-cl-9IZ" id="WzF-v2-Uab"/>
+                <outlet property="overlayModeExplanationLabel" destination="TQ4-4q-pDK" id="l0D-Yc-cKF"/>
+                <outlet property="overlayModeLabel" destination="59c-ru-ZaX" id="daD-9Q-jj5"/>
+                <outlet property="overlayModeStackView" destination="C1w-tz-L80" id="5S9-nn-Ry7"/>
+                <outlet property="overlayModeSwitch" destination="ucq-p0-xPZ" id="1lx-bx-UUx"/>
                 <outlet property="safariOpenerExplanationLabel" destination="wRp-wI-i3X" id="5XS-KG-kbq"/>
                 <outlet property="safariOpenerLabel" destination="sqW-mn-jeX" id="5EF-5h-nbp"/>
                 <outlet property="safariOpenerSwitch" destination="yPy-Cf-ZtJ" id="tf1-ge-WHK"/>
@@ -37,10 +41,10 @@
                     <rect key="frame" x="0.0" y="44" width="375" height="768"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hkm-EY-XLf">
-                            <rect key="frame" x="0.0" y="0.0" width="375.33333333333331" height="450"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375.33333333333331" height="548"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="uNS-na-vvN">
-                                    <rect key="frame" x="18" y="18" width="339.33333333333331" height="254"/>
+                                    <rect key="frame" x="18" y="18" width="339.33333333333331" height="352"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="VKH-4H-gvf">
                                             <rect key="frame" x="0.0" y="0.0" width="339.33333333333331" height="58"/>
@@ -129,10 +133,40 @@
                                                 </label>
                                             </subviews>
                                         </stackView>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="cu7-Pr-3Eb">
+                                            <rect key="frame" x="0.0" y="294" width="339.33333333333331" height="58"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="C1w-tz-L80">
+                                                    <rect key="frame" x="0.0" y="0.0" width="339.33333333333331" height="31"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="59c-ru-ZaX">
+                                                            <rect key="frame" x="0.0" y="5.3333333333333144" width="285.33333333333331" height="20.333333333333332"/>
+                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ucq-p0-xPZ">
+                                                            <rect key="frame" x="290.33333333333331" y="0.0" width="51" height="31"/>
+                                                            <color key="onTintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <connections>
+                                                                <action selector="overlayModeChanged:" destination="-1" eventType="valueChanged" id="Ji3-Gb-M8C"/>
+                                                                <action selector="safariReaderModeChanged:" destination="-1" eventType="valueChanged" id="t9t-HD-wND"/>
+                                                            </connections>
+                                                        </switch>
+                                                    </subviews>
+                                                </stackView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TQ4-4q-pDK">
+                                                    <rect key="frame" x="0.0" y="41" width="339.33333333333331" height="17"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
                                     </subviews>
                                 </stackView>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="geg-cl-9IZ">
-                                    <rect key="frame" x="37.666666666666657" y="312" width="300" height="51"/>
+                                    <rect key="frame" x="37.666666666666657" y="410" width="300" height="51"/>
                                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="wZp-a3-zqo"/>
@@ -152,7 +186,7 @@
                                     </connections>
                                 </button>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="spg-UY-3vD">
-                                    <rect key="frame" x="38" y="383" width="299.33333333333331" height="47"/>
+                                    <rect key="frame" x="38" y="481" width="299.33333333333331" height="47"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="0jc-Qd-nlT">
                                             <rect key="frame" x="56.333333333333314" y="0.0" width="187" height="25"/>

--- a/llitgi/ViewControllers/SplitViewController.swift
+++ b/llitgi/ViewControllers/SplitViewController.swift
@@ -19,7 +19,6 @@ class SplitViewController: UISplitViewController {
     init(factory: ViewControllerFactory) {
         self.factory = factory
         super.init(nibName: nil, bundle: nil)
-        preferredDisplayMode = .allVisible
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -30,12 +29,31 @@ class SplitViewController: UISplitViewController {
         let master = TabBarController(factory: factory)
         master.setupMainFlow()
         self.viewControllers = [master]
+        preferredDisplayMode = .allVisible
     }
 }
-
 
 extension SplitViewController: SafariShowing {
     func show(safariViewController: SFSafariViewController) {
         showDetailViewController(safariViewController, sender: self)
     }
+}
+
+extension SplitViewController: OverlayDisplaying {
+    func overlayDisplayMode(shouldBeSet: Bool) {
+        DispatchQueue.main.async {
+            if shouldBeSet {
+                self.preferredDisplayMode = .primaryOverlay
+                print("Setting preferredDisplayMode to primaryOverlay")
+            } else {
+                self.preferredDisplayMode = .allVisible
+                print("Setting preferredDisplayMode to allVisible")
+            }
+        }
+    }
+    
+    func isOverlayDisplayModeSet() -> Bool {
+        return preferredDisplayMode == .primaryOverlay
+    }
+    
 }

--- a/llitgi/ViewControllers/SplitViewController.swift
+++ b/llitgi/ViewControllers/SplitViewController.swift
@@ -28,7 +28,8 @@ class SplitViewController: UISplitViewController {
     func setupMainFlow(shouldEnableOverlayMode: Bool) {
         let master = TabBarController(factory: factory)
         master.setupMainFlow()
-        self.viewControllers = [master]
+        let emptyDetail = factory.instantiateEmptyDetail()
+        self.viewControllers = [master, emptyDetail]
         if (shouldEnableOverlayMode) {
             preferredDisplayMode = .primaryOverlay
         } else {
@@ -39,6 +40,7 @@ class SplitViewController: UISplitViewController {
 
 extension SplitViewController: SafariShowing {
     func show(safariViewController: SFSafariViewController) {
+        safariViewController.delegate = self
         showDetailViewController(safariViewController, sender: self)
     }
 }
@@ -46,9 +48,17 @@ extension SplitViewController: SafariShowing {
 extension SplitViewController: OverlayDisplaying {
     func overlayDisplayMode(isEnabled: Bool) {
         if (isEnabled) {
-            self.preferredDisplayMode = .primaryOverlay
+            preferredDisplayMode = .primaryOverlay
         } else {
-            self.preferredDisplayMode = .allVisible
+            preferredDisplayMode = .allVisible
         }
     }
 }
+
+extension SplitViewController: SFSafariViewControllerDelegate {
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        let emptyDetail = factory.instantiateEmptyDetail()
+        showDetailViewController(emptyDetail, sender: self)
+    }
+}
+

--- a/llitgi/ViewControllers/SplitViewController.swift
+++ b/llitgi/ViewControllers/SplitViewController.swift
@@ -25,11 +25,15 @@ class SplitViewController: UISplitViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func setupMainFlow() {
+    func setupMainFlow(shouldEnableOverlayMode: Bool) {
         let master = TabBarController(factory: factory)
         master.setupMainFlow()
         self.viewControllers = [master]
-        preferredDisplayMode = .allVisible
+        if (shouldEnableOverlayMode) {
+            preferredDisplayMode = .primaryOverlay
+        } else {
+            preferredDisplayMode = .allVisible
+        }
     }
 }
 
@@ -40,20 +44,11 @@ extension SplitViewController: SafariShowing {
 }
 
 extension SplitViewController: OverlayDisplaying {
-    func overlayDisplayMode(shouldBeSet: Bool) {
-        DispatchQueue.main.async {
-            if shouldBeSet {
-                self.preferredDisplayMode = .primaryOverlay
-                print("Setting preferredDisplayMode to primaryOverlay")
-            } else {
-                self.preferredDisplayMode = .allVisible
-                print("Setting preferredDisplayMode to allVisible")
-            }
+    func overlayDisplayMode(isEnabled: Bool) {
+        if (isEnabled) {
+            self.preferredDisplayMode = .primaryOverlay
+        } else {
+            self.preferredDisplayMode = .allVisible
         }
     }
-    
-    func isOverlayDisplayModeSet() -> Bool {
-        return preferredDisplayMode == .primaryOverlay
-    }
-    
 }

--- a/llitgi/ViewControllers/SplitViewController.swift
+++ b/llitgi/ViewControllers/SplitViewController.swift
@@ -1,0 +1,41 @@
+//
+//  SplitViewController.swift
+//  llitgi
+//
+//  Created by Adrian Tineo on 24.07.18.
+//  Copyright © 2018 xmollv. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import SafariServices
+
+class SplitViewController: UISplitViewController {
+    
+    //MARK: Private properties
+    private let factory: ViewControllerFactory
+    
+    //MARK: Lifecycle
+    init(factory: ViewControllerFactory) {
+        self.factory = factory
+        super.init(nibName: nil, bundle: nil)
+        preferredDisplayMode = .allVisible
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setupMainFlow() {
+        let master = TabBarController(factory: factory)
+        master.setupMainFlow()
+        self.viewControllers = [master]
+    }
+}
+
+
+extension SplitViewController: SafariShowing {
+    func show(safariViewController: SFSafariViewController) {
+        showDetailViewController(safariViewController, sender: self)
+    }
+}

--- a/llitgi/ViewControllers/SplitViewController.swift
+++ b/llitgi/ViewControllers/SplitViewController.swift
@@ -28,8 +28,12 @@ class SplitViewController: UISplitViewController {
     func setupMainFlow(shouldEnableOverlayMode: Bool) {
         let master = TabBarController(factory: factory)
         master.setupMainFlow()
-        let emptyDetail = factory.instantiateEmptyDetail()
-        self.viewControllers = [master, emptyDetail]
+        var viewControllers : [UIViewController] = [master]
+        if (UIDevice.current.userInterfaceIdiom == .pad) {
+            let emptyDetail = factory.instantiateEmptyDetail()
+            viewControllers.append(emptyDetail)
+        }
+        self.viewControllers = viewControllers
         if (shouldEnableOverlayMode) {
             preferredDisplayMode = .primaryOverlay
         } else {
@@ -57,8 +61,10 @@ extension SplitViewController: OverlayDisplaying {
 
 extension SplitViewController: SFSafariViewControllerDelegate {
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-        let emptyDetail = factory.instantiateEmptyDetail()
-        showDetailViewController(emptyDetail, sender: self)
+        if (UIDevice.current.userInterfaceIdiom == .pad) {
+            let emptyDetail = factory.instantiateEmptyDetail()
+            showDetailViewController(emptyDetail, sender: self)
+        }
     }
 }
 

--- a/llitgi/ViewControllers/ViewControllerFactory.swift
+++ b/llitgi/ViewControllers/ViewControllerFactory.swift
@@ -51,4 +51,8 @@ final class ViewControllerFactory {
     func instantiateFullSync() -> FullSyncViewController {
         return FullSyncViewController(dataProvider: self.dataProvider)
     }
+    
+    func instantiateEmptyDetail() -> EmptyDetailViewController {
+        return EmptyDetailViewController(nibName: String(describing: EmptyDetailViewController.self), bundle: nil)
+    }
 }

--- a/llitgi/ViewControllers/ViewControllerFactory.swift
+++ b/llitgi/ViewControllers/ViewControllerFactory.swift
@@ -14,8 +14,9 @@ final class ViewControllerFactory {
     //MARK: Private properties
     private let dataProvider: DataProvider
     private let userManager: UserManager
-    private let flowManager: FlowManager
-    var safariShowing: SafariShowing!
+    
+    private weak var flowManager: FlowManager?
+    weak var safariShowing: SafariShowing?
     
     //MARK: Lifecycle
     init(dataProvider: DataProvider, userManager: UserManager, flowManager: FlowManager) {
@@ -26,11 +27,17 @@ final class ViewControllerFactory {
     
     //MARK: Public methods
     func instantiateAuth() -> AuthorizationViewController {
-        return AuthorizationViewController(dataProvider: self.dataProvider, factory: self, flowManager: self.flowManager)
+        guard let flowManager = flowManager else {
+            fatalError("need to inject flowManager into ViewControllerFactory")
+        }
+        return AuthorizationViewController(dataProvider: self.dataProvider, factory: self, flowManager: flowManager)
     }
     
     func instantiateList(for type: TypeOfList) -> ListViewController {
-        return ListViewController(dataProvider: self.dataProvider, factory: self, userManager: self.userManager, type: type, flowManager: self.flowManager, safariShowing: safariShowing)
+        guard let flowManager = flowManager , let safariShowing = safariShowing else {
+            fatalError("need to inject flowManager and safariShowing into ViewControllerFactory")
+        }
+        return ListViewController(dataProvider: self.dataProvider, factory: self, userManager: self.userManager, type: type, flowManager: flowManager, safariShowing: safariShowing)
     }
     
     func instantiateSettings() -> SettingsViewController {

--- a/llitgi/ViewControllers/ViewControllerFactory.swift
+++ b/llitgi/ViewControllers/ViewControllerFactory.swift
@@ -17,6 +17,7 @@ final class ViewControllerFactory {
     
     private weak var flowManager: FlowManager?
     weak var safariShowing: SafariShowing?
+    weak var overlayDisplaying: OverlayDisplaying?
     
     //MARK: Lifecycle
     init(dataProvider: DataProvider, userManager: UserManager, flowManager: FlowManager) {
@@ -41,7 +42,10 @@ final class ViewControllerFactory {
     }
     
     func instantiateSettings() -> SettingsViewController {
-        return SettingsViewController(userManager: self.userManager)
+        guard let overlayDisplaying = overlayDisplaying else {
+            fatalError("need to inject overlayDisplaying into ViewControllerFactory")
+        }
+        return SettingsViewController(userManager: self.userManager, overlayDisplaying: overlayDisplaying)
     }
     
     func instantiateFullSync() -> FullSyncViewController {

--- a/llitgi/ViewControllers/ViewControllerFactory.swift
+++ b/llitgi/ViewControllers/ViewControllerFactory.swift
@@ -14,20 +14,23 @@ final class ViewControllerFactory {
     //MARK: Private properties
     private let dataProvider: DataProvider
     private let userManager: UserManager
+    private let flowManager: FlowManager
+    var safariShowing: SafariShowing!
     
     //MARK: Lifecycle
-    init(dataProvider: DataProvider, userManager: UserManager) {
+    init(dataProvider: DataProvider, userManager: UserManager, flowManager: FlowManager) {
         self.dataProvider = dataProvider
         self.userManager = userManager
+        self.flowManager = flowManager
     }
     
     //MARK: Public methods
     func instantiateAuth() -> AuthorizationViewController {
-        return AuthorizationViewController(dataProvider: self.dataProvider, factory: self)
+        return AuthorizationViewController(dataProvider: self.dataProvider, factory: self, flowManager: self.flowManager)
     }
     
     func instantiateList(for type: TypeOfList) -> ListViewController {
-        return ListViewController(dataProvider: self.dataProvider, factory: self, userManager: self.userManager, type: type)
+        return ListViewController(dataProvider: self.dataProvider, factory: self, userManager: self.userManager, type: type, flowManager: self.flowManager, safariShowing: safariShowing)
     }
     
     func instantiateSettings() -> SettingsViewController {


### PR DESCRIPTION
Fix #23 

I added support for iPad as universal app, following @xmollv guidelines in issue #23.

This is what it looks like after the changes.

**iPhone portrait**
![iphone_portrait_list](https://user-images.githubusercontent.com/12340433/43678396-ed10e5b4-9812-11e8-998c-631c4d0e7703.png)

**iPad portrait**
![ipad_portrait_no_overlay](https://user-images.githubusercontent.com/12340433/43678398-fae98fce-9812-11e8-8df1-fdca0579359a.png)

**iPad lanscape**
![ipad_landscape_no_overlay](https://user-images.githubusercontent.com/12340433/43678401-0258ea3e-9813-11e8-9ffb-d345605acefb.png)

Let me break down the commits as well as provide some additional images.

At commit 704294d, I have made the `SplitViewController` be the `rootViewController` for the main flow. For the auth flow, I still keep the `TabBarController` as the `rootViewController`. I have extracted the flow creation from the `AppDelegate` into the new object `FlowManager`. Now the `ListViewController` tells the `SplitViewController` to show the `safariViewController` through delegation via protocol `SafariShowing`. This already enables to base the navigation of the main flow on the `SplitViewController` and the change of flows when logging out and returning to the auth flow.

At commits f2dda5c and 010b8cd, I added weak references to prevent memory cycles when changing flows. 

At commits 560f9e7 and cceed71 I took the liberty to create a new switch in the `SettingsViewController` to enable the `overlayMode` for the `SplitViewController`. This enables the full screen reading of articles on iPad. Initially, the primary view controller (master) is laid over the secondary view controller (detail), with the article. By tapping on the detail, the master is hidden. It can be revealed by swiping from the left. Here are some screenshots. 

**Without overlay**
![ipad_landscape_no_overlay](https://user-images.githubusercontent.com/12340433/43678488-6e11cede-9814-11e8-8b4b-ca171fdb824a.png)

**With overlay, master expanded**
![ipad_portrait_overlay_expanded](https://user-images.githubusercontent.com/12340433/43678498-9289643e-9814-11e8-9990-82298e276608.png)

**With overlay, master collapsed**
![ipad_portrait_overlay_collapsed](https://user-images.githubusercontent.com/12340433/43678500-996c0bee-9814-11e8-9ced-861055cfc212.png)

The following commits are small, incremental changes to:

- show the settings screen more compact (initially pageSheet, later formSheet), this only has effect on iPad, it remains unchanged for iPhone
![ipad_settings_portrait_formsheet](https://user-images.githubusercontent.com/12340433/43678512-d872a096-9814-11e8-922b-b2786113fec9.png)
![iphone_settings_formsheet](https://user-images.githubusercontent.com/12340433/43678517-e7966e04-9814-11e8-970c-afbb7489150e.png)

- add empty detail page for the case where there is no article yet selected on iPad
![ipad_portrait_empty_detail_no_overlay](https://user-images.githubusercontent.com/12340433/43678525-066c21ac-9815-11e8-9bb7-d1acdf253d80.png)

- add readable guide for welcome, settings and empty detail
![ipad_landscape_welcome](https://user-images.githubusercontent.com/12340433/43678528-2e25a074-9815-11e8-9a3b-c287dd46b7cf.png)

I couldn't add the icons for iPad because I don't have the assets.

One additional comment about the overlay mode. I have tried for hours to make the collapsed master reveal when tapping on the done button on the safariViewController in the detail, but I was unsuccessful. As it is right now, the user needs to swipe from the left when done reading one article. I would have preferred to have the list reveal when tapping on "done", to be able to directly act on the list but like I said I could not find a way to do that 😣

Hope that helps and that we can all soon have an iPad-ready version on the App Store 😃 Of course, feel free to revert or change what you don't like.



