### PR TITLE
Looped over every attachment to look for URLs

### DIFF
--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.2</string>
+	<string>3.1.3</string>
 	<key>CFBundleVersion</key>
-	<string>29</string>
+	<string>30</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/llitgi/Resources/Info.plist
+++ b/llitgi/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.2</string>
+	<string>3.1.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>29</string>
+	<string>30</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
This PR fixes the bug reported on #69. For now if the share contains more than one URL, we will only grab the first one but it won't fail if the share is Text + URL because we look for URLs instead of just grabbing the first attachment.